### PR TITLE
Add "emptyview_" prefix to strings and dimensions

### DIFF
--- a/app/src/main/java/com/santalu/myapplication/MainActivity.java
+++ b/app/src/main/java/com/santalu/myapplication/MainActivity.java
@@ -105,7 +105,7 @@ public class MainActivity extends AppCompatActivity implements OnClickListener {
 
     public void showError(Throwable throwable) {
         if (throwable == null || TextUtils.isEmpty(throwable.getMessage())) {
-            showError(R.string.error_unknown);
+            showError(R.string.emptyview_error_unknown);
             return;
         }
         Error error = Error.find(throwable);
@@ -123,15 +123,15 @@ public class MainActivity extends AppCompatActivity implements OnClickListener {
     }
 
     public void showConnectionError() {
-        showError(R.string.error_connection_not_found);
+        showError(R.string.emptyview_error_connection_not_found);
     }
 
     public void showTimeoutError() {
-        showError(R.string.error_connection_timeout);
+        showError(R.string.emptyview_error_connection_timeout);
     }
 
     public void showEndpointError() {
-        showError(R.string.error_endpoint);
+        showError(R.string.emptyview_error_endpoint);
     }
 
     enum Error {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,11 +15,11 @@
     app:errorButtonTextColor="@color/black"
     app:errorDrawable="@drawable/ic_sentiment_very_dissatisfied"
     app:errorDrawableTint="@color/white"
-    app:errorText="@string/error_unknown"
+    app:errorText="@string/emptyview_error_unknown"
     app:errorTextColor="@color/white"
     app:loadingDrawable="@drawable/ic_sentiment_satisfied"
     app:loadingStyle="circular"
-    app:loadingText="@string/loading"
+    app:loadingText="@string/emptyview_loading"
     app:loadingTint="@color/colorPrimary">
 
     <TextView

--- a/library/src/main/res/layout/empty_view.xml
+++ b/library/src/main/res/layout/empty_view.xml
@@ -8,39 +8,39 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical"
-        android:padding="@dimen/dialog_spacing_medium"
+        android:padding="@dimen/emptyview_dialog_spacing_medium"
         android:visibility="gone">
 
         <ImageView
             android:id="@+id/empty_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/dialog_spacing_normal"/>
+            android:layout_marginBottom="@dimen/emptyview_dialog_spacing_normal"/>
 
         <ProgressBar
             android:id="@+id/empty_progress_bar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/dialog_spacing_normal"/>
+            android:layout_marginBottom="@dimen/emptyview_dialog_spacing_normal"/>
 
         <TextView
             android:id="@+id/empty_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/dialog_spacing_normal"
+            android:layout_marginBottom="@dimen/emptyview_dialog_spacing_normal"
             android:gravity="center"
-            android:lineSpacingExtra="@dimen/dialog_text_spacing"
-            android:textSize="@dimen/dialog_text_size"/>
+            android:lineSpacingExtra="@dimen/emptyview_dialog_text_spacing"
+            android:textSize="@dimen/emptyview_dialog_text_size"/>
 
         <Button
             android:id="@+id/empty_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/dialog_spacing_small"
-            android:paddingLeft="@dimen/dialog_spacing_normal"
-            android:paddingRight="@dimen/dialog_spacing_normal"
-            android:paddingTop="@dimen/dialog_spacing_small"
-            android:textSize="@dimen/dialog_text_size"/>
+            android:paddingBottom="@dimen/emptyview_dialog_spacing_small"
+            android:paddingLeft="@dimen/emptyview_dialog_spacing_normal"
+            android:paddingRight="@dimen/emptyview_dialog_spacing_normal"
+            android:paddingTop="@dimen/emptyview_dialog_spacing_small"
+            android:textSize="@dimen/emptyview_dialog_text_size"/>
 
     </LinearLayout>
 

--- a/library/src/main/res/values-en/strings.xml
+++ b/library/src/main/res/values-en/strings.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <string name="loading">Loading…</string>
-    <string name="error_connection_not_found">No connection! Please check your connection settings.</string>
-    <string name="error_connection_timeout">Connection timed out!</string>
-    <string name="error_endpoint">Unable to access the connection address!</string>
-    <string name="error_unknown">We can not fulfill your request now. Please try again later!</string>
-
+    <string name="emptyview_loading">Loading…</string>
+    <string name="emptyview_error_connection_not_found">No connection! Please check your connection settings.</string>
+    <string name="emptyview_error_connection_timeout">Connection timed out!</string>
+    <string name="emptyview_error_endpoint">Unable to access the connection address!</string>
+    <string name="emptyview_error_unknown">We can not fulfill your request now. Please try again later!</string>
 </resources>

--- a/library/src/main/res/values-sw600dp/dimens.xml
+++ b/library/src/main/res/values-sw600dp/dimens.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <dimen name="dialog_spacing_lite">6dp</dimen>
-    <dimen name="dialog_spacing_small">10dp</dimen>
-    <dimen name="dialog_spacing_normal">18dp</dimen>
-    <dimen name="dialog_spacing_medium">22dp</dimen>
-    <dimen name="dialog_spacing_large">26dp</dimen>
-    <dimen name="dialog_text_spacing">6dp</dimen>
-    <dimen name="dialog_text_size">20sp</dimen>
-
+    <dimen name="emptyview_dialog_spacing_lite">6dp</dimen>
+    <dimen name="emptyview_dialog_spacing_small">10dp</dimen>
+    <dimen name="emptyview_dialog_spacing_normal">18dp</dimen>
+    <dimen name="emptyview_dialog_spacing_medium">22dp</dimen>
+    <dimen name="emptyview_dialog_spacing_large">26dp</dimen>
+    <dimen name="emptyview_dialog_text_spacing">6dp</dimen>
+    <dimen name="emptyview_dialog_text_size">20sp</dimen>
 </resources>

--- a/library/src/main/res/values-sw720dp/dimens.xml
+++ b/library/src/main/res/values-sw720dp/dimens.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <dimen name="dialog_spacing_lite">8dp</dimen>
-    <dimen name="dialog_spacing_small">12dp</dimen>
-    <dimen name="dialog_spacing_normal">20dp</dimen>
-    <dimen name="dialog_spacing_medium">24dp</dimen>
-    <dimen name="dialog_spacing_large">28dp</dimen>
-    <dimen name="dialog_text_spacing">8dp</dimen>
-    <dimen name="dialog_text_size">22sp</dimen>
-
+    <dimen name="emptyview_dialog_spacing_lite">8dp</dimen>
+    <dimen name="emptyview_dialog_spacing_small">12dp</dimen>
+    <dimen name="emptyview_dialog_spacing_normal">20dp</dimen>
+    <dimen name="emptyview_dialog_spacing_medium">24dp</dimen>
+    <dimen name="emptyview_dialog_spacing_large">28dp</dimen>
+    <dimen name="emptyview_dialog_text_spacing">8dp</dimen>
+    <dimen name="emptyview_dialog_text_size">22sp</dimen>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <declare-styleable name="EmptyView">
-        <attr format="enum" name="emptyGravity">
-            <enum name="center" value="0"/>
-            <enum name="top" value="1"/>
-            <enum name="bottom" value="2"/>
+        <attr name="emptyGravity" format="enum">
+            <enum name="center" value="0" />
+            <enum name="top" value="1" />
+            <enum name="bottom" value="2" />
         </attr>
         <attr name="loadingStyle">
-            <enum name="circular" value="0"/>
-            <enum name="linear" value="1"/>
-            <enum name="text" value="2"/>
+            <enum name="circular" value="0" />
+            <enum name="linear" value="1" />
+            <enum name="text" value="2" />
         </attr>
-        <attr format="string" name="loadingText"/>
-        <attr format="color" name="loadingTextColor"/>
-        <attr format="reference" name="loadingDrawable"/>
-        <attr format="color" name="loadingTint"/>
-        <attr format="color" name="loadingBackgroundColor"/>
-        <attr format="string" name="emptyText"/>
-        <attr format="color" name="emptyTextColor"/>
-        <attr format="reference" name="emptyDrawable"/>
-        <attr format="color" name="emptyDrawableTint"/>
-        <attr format="color" name="emptyBackgroundColor"/>
-        <attr format="string" name="errorText"/>
-        <attr format="color" name="errorTextColor"/>
-        <attr format="reference" name="errorDrawable"/>
-        <attr format="color" name="errorDrawableTint"/>
-        <attr format="color" name="errorBackgroundColor"/>
-        <attr format="string" name="errorButtonText"/>
-        <attr format="color" name="errorButtonTextColor"/>
-        <attr format="color" name="errorButtonBackgroundColor"/>
+        <attr name="loadingText" format="string" />
+        <attr name="loadingTextColor" format="color" />
+        <attr name="loadingDrawable" format="reference" />
+        <attr name="loadingTint" format="color" />
+        <attr name="loadingBackgroundColor" format="color" />
+        <attr name="emptyText" format="string" />
+        <attr name="emptyTextColor" format="color" />
+        <attr name="emptyDrawable" format="reference" />
+        <attr name="emptyDrawableTint" format="color" />
+        <attr name="emptyBackgroundColor" format="color" />
+        <attr name="errorText" format="string" />
+        <attr name="errorTextColor" format="color" />
+        <attr name="errorDrawable" format="reference" />
+        <attr name="errorDrawableTint" format="color" />
+        <attr name="errorBackgroundColor" format="color" />
+        <attr name="errorButtonText" format="string" />
+        <attr name="errorButtonTextColor" format="color" />
+        <attr name="errorButtonBackgroundColor" format="color" />
     </declare-styleable>
-
 </resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <dimen name="dialog_spacing_lite">4dp</dimen>
-    <dimen name="dialog_spacing_small">8dp</dimen>
-    <dimen name="dialog_spacing_normal">16dp</dimen>
-    <dimen name="dialog_spacing_medium">20dp</dimen>
-    <dimen name="dialog_spacing_large">24dp</dimen>
-    <dimen name="dialog_text_spacing">4dp</dimen>
-    <dimen name="dialog_text_size">18sp</dimen>
+    <dimen name="emptyview_dialog_spacing_lite">4dp</dimen>
+    <dimen name="emptyview_dialog_spacing_small">8dp</dimen>
+    <dimen name="emptyview_dialog_spacing_normal">16dp</dimen>
+    <dimen name="emptyview_dialog_spacing_medium">20dp</dimen>
+    <dimen name="emptyview_dialog_spacing_large">24dp</dimen>
+    <dimen name="emptyview_dialog_text_spacing">4dp</dimen>
+    <dimen name="emptyview_dialog_text_size">18sp</dimen>
 
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,9 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <string name="loading">Yükleniyor…</string>
-    <string name="error_unknown">İsteğinizi şuanda gerçekleştiremiyoruz.\nLütfen daha sonra tekrar deneyin!</string>
-    <string name="error_connection_not_found">Lütfen bağlantı ayarlarınızı kontrol edin ve tekrar deneyin.</string>
-    <string name="error_connection_timeout">Bağlantı zaman aşımına uğradı!</string>
-    <string name="error_endpoint">Bağlantı adresine erişilemiyor!</string>
-
+    <string name="emptyview_loading">Yükleniyor…</string>
+    <string name="emptyview_error_unknown">İsteğinizi şuanda gerçekleştiremiyoruz.\nLütfen daha sonra tekrar deneyin!</string>
+    <string name="emptyview_error_connection_not_found">Lütfen bağlantı ayarlarınızı kontrol edin ve tekrar deneyin.</string>
+    <string name="emptyview_error_connection_timeout">Bağlantı zaman aşımına uğradı!</string>
+    <string name="emptyview_error_endpoint">Bağlantı adresine erişilemiyor!</string>
 </resources>


### PR DESCRIPTION
Prefix strings resources and dimensions resources with `emptyview_`, avoiding conflict/unwanted overrides when using the library