### PR TITLE
Provide English translations as default instead of Turkish

### DIFF
--- a/library/src/main/res/values-en/strings.xml
+++ b/library/src/main/res/values-en/strings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="emptyview_loading">Loading…</string>
-    <string name="emptyview_error_unknown">We can not fulfill your request now. Please try again later!</string>
-    <string name="emptyview_error_connection_not_found">No connection! Please check your connection settings.</string>
-    <string name="emptyview_error_connection_timeout">Connection timed out!</string>
-    <string name="emptyview_error_endpoint">Unable to access the connection address!</string>
-</resources>

--- a/library/src/main/res/values-tr/strings.xml
+++ b/library/src/main/res/values-tr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="emptyview_loading">Yükleniyor…</string>
+    <string name="emptyview_error_unknown">İsteğinizi şuanda gerçekleştiremiyoruz.\nLütfen daha sonra tekrar deneyin!</string>
+    <string name="emptyview_error_connection_not_found">Lütfen bağlantı ayarlarınızı kontrol edin ve tekrar deneyin.</string>
+    <string name="emptyview_error_connection_timeout">Bağlantı zaman aşımına uğradı!</string>
+    <string name="emptyview_error_endpoint">Bağlantı adresine erişilemiyor!</string>
+</resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="emptyview_loading">Yükleniyor…</string>
-    <string name="emptyview_error_unknown">İsteğinizi şuanda gerçekleştiremiyoruz.\nLütfen daha sonra tekrar deneyin!</string>
-    <string name="emptyview_error_connection_not_found">Lütfen bağlantı ayarlarınızı kontrol edin ve tekrar deneyin.</string>
-    <string name="emptyview_error_connection_timeout">Bağlantı zaman aşımına uğradı!</string>
-    <string name="emptyview_error_endpoint">Bağlantı adresine erişilemiyor!</string>
+    <string name="emptyview_loading">Loading…</string>
+    <string name="emptyview_error_unknown">We can not fulfill your request now. Please try again later!</string>
+    <string name="emptyview_error_connection_not_found">No connection! Please check your connection settings.</string>
+    <string name="emptyview_error_connection_timeout">Connection timed out!</string>
+    <string name="emptyview_error_endpoint">Unable to access the connection address!</string>
 </resources>


### PR DESCRIPTION
IMO, English should be the default/fallback values.

I guessed (thanks to Google Translate) that the other language was Turkish. Sorry if I'm wrong.